### PR TITLE
[Feature] - Clear mail list once all mails are send, to avoid duplicate send

### DIFF
--- a/Mailer/SendGridMailer.php
+++ b/Mailer/SendGridMailer.php
@@ -160,9 +160,8 @@ class SendGridMailer implements MailerInterface
     public function send()
     {
         $mailIsSent  = false;
-        $mailsToSend = $this->mailList;
 
-        while (is_array($mailsToSend) && ($mail = array_shift($mailsToSend)) && $mail instanceof EmailInterface) {
+        while (is_array($this->mailList) && ($mail = array_shift($this->mailList)) && $mail instanceof EmailInterface) {
             if (!(is_array($this->options))) {
                 throw new MailerException('You need to prepare the mail that will be sent.');
             }


### PR DESCRIPTION
#### What's this PR do ?

This feature clear mail list once it has been send by sendGrid.
The goal is if one mail has already been add to mail list, to avoid that when we want to send a new mail, to resend the first one.